### PR TITLE
fix: always normalize slashes to unix in SourceFilesManager

### DIFF
--- a/src/SourceFilesManager.ts
+++ b/src/SourceFilesManager.ts
@@ -91,6 +91,7 @@ export class SourceFilesManager {
    * build.
    */
   public add (filePath: string): void {
+    filePath = this._normalizeSlashToUnix(filePath)
     this._projectFiles[filePath] = this._projectFiles[filePath] || { version: 1 }
     debug('adding new source file "%s"', filePath)
   }
@@ -100,6 +101,7 @@ export class SourceFilesManager {
    * typescript compiler that file has been changed.
    */
   public bumpVersion (filePath: string) {
+    filePath = this._normalizeSlashToUnix(filePath)
     const projectFile = this._projectFiles[filePath]
     if (!projectFile) {
       return
@@ -113,6 +115,7 @@ export class SourceFilesManager {
    * Remove file from the list of existing source files
    */
   public remove (filePath: string) {
+    filePath = this._normalizeSlashToUnix(filePath)
     debug('removing source file "%s"', filePath)
     delete this._projectFiles[filePath]
   }
@@ -122,6 +125,7 @@ export class SourceFilesManager {
    * them against `includes`, `excludes` and custom set of `files`.
    */
   public isSourceFile (filePath: string): boolean {
+    filePath = this._normalizeSlashToUnix(filePath)
     return (!!this._projectFiles[filePath]) || this._matchAgainstPattern(filePath)
   }
 
@@ -129,6 +133,7 @@ export class SourceFilesManager {
    * Returns file version
    */
   public getFileVersion (filePath: string): null | number {
+    filePath = this._normalizeSlashToUnix(filePath)
     const projectFile = this._projectFiles[filePath]
     return projectFile ? projectFile.version : null
   }

--- a/test/source-files-manager.spec.ts
+++ b/test/source-files-manager.spec.ts
@@ -15,6 +15,10 @@ import { parseTsConfig } from '../test-helpers'
 
 const fs = new Filesystem(join(__dirname, 'app'))
 
+function joinUnix (...paths: string[]): string {
+  return join(...paths).replace(/\\/g, '/')
+}
+
 test.group('Source Files Manager', (group) => {
   group.afterEach(async () => {
     await fs.cleanup()
@@ -42,7 +46,7 @@ test.group('Source Files Manager', (group) => {
     )
 
     assert.deepEqual(sourceFilesManager.toJSON(), {
-      [join(fs.basePath, 'foo', 'bar', 'baz.ts')]: {
+      [joinUnix(fs.basePath, 'foo', 'bar', 'baz.ts')]: {
         version: 1,
       },
     })
@@ -89,7 +93,7 @@ test.group('Source Files Manager', (group) => {
 
     sourceFilesManager.add(join(fs.basePath, './foo', 'baz.ts'))
     assert.deepEqual(sourceFilesManager.toJSON(), {
-      [join(fs.basePath, './foo', 'baz.ts')]: { version: 1 },
+      [joinUnix(fs.basePath, './foo', 'baz.ts')]: { version: 1 },
     })
   })
 
@@ -112,7 +116,7 @@ test.group('Source Files Manager', (group) => {
 
     sourceFilesManager.bumpVersion(join(fs.basePath, './foo', 'bar', 'baz.ts'))
     assert.deepEqual(sourceFilesManager.toJSON(), {
-      [join(fs.basePath, './foo', 'bar', 'baz.ts')]: { version: 2 },
+      [joinUnix(fs.basePath, './foo', 'bar', 'baz.ts')]: { version: 2 },
     })
   })
 


### PR DESCRIPTION
The _projectFiles map contains normalized paths but the watcher
passes them with backslashes on Windows.
